### PR TITLE
Fix run instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ go mod tidy
 
 ### **3. Run the Application**
 ```bash
-go run cmd/main.go
+go run cmd/server/main.go
 ```
 
 ### **4. Test the API**


### PR DESCRIPTION
## Summary
- fix README's Run the Application command

## Testing
- `go test ./...` *(fails: Get https://proxy.golang.org... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68645c052ea8832daad064935bf08d0a